### PR TITLE
Refactor MultiplexMenu to work through the "submit modal" pipeline

### DIFF
--- a/documentation/dependents.json
+++ b/documentation/dependents.json
@@ -482,6 +482,7 @@
     "Hexagon/FullScreenOverlay/Stage",
     "Hexagon/GitCommitMessageInputBox/Stage",
     "Hexagon/MissingFile/Stage",
+    "Hexagon/MultiplexMenu/CommandExecutor",
     "Hexagon/MultiplexMenu/Stage",
     "Hexagon/MultiplexMenu/Stage",
     "Hexagon/NewComponentMaker/Stage",
@@ -1299,6 +1300,13 @@
   "Hexagon/Elements/TexturedRectangle": [
     "Hexagon/MissingFile/Stage"
   ],
+  "Hexagon/MultiplexMenu/MultiplexMenu": [
+    "Hexagon/MultiplexMenu/CommandExecutor",
+    "Hexagon/MultiplexMenu/Renderer",
+    "Hexagon/MultiplexMenu/Stage",
+    "Hexagon/MultiplexMenu/Stage",
+    "Hexagon/StageFactory"
+  ],
   "Hexagon/KeyboardCommandKey": [
     "Hexagon/MultiplexMenu/MenuItem",
     "Hexagon/MultiplexMenu/MultiplexMenuPage",
@@ -1335,12 +1343,6 @@
   "AllegroFlare/color": [
     "Hexagon/MultiplexMenu/PageRenderer",
     "Hexagon/MultiplexMenu/Renderer"
-  ],
-  "Hexagon/MultiplexMenu/MultiplexMenu": [
-    "Hexagon/MultiplexMenu/Renderer",
-    "Hexagon/MultiplexMenu/Stage",
-    "Hexagon/MultiplexMenu/Stage",
-    "Hexagon/StageFactory"
   ],
   "Hexagon/MultiplexMenu/PageRenderer": [
     "Hexagon/MultiplexMenu/Renderer"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -149,6 +149,7 @@ table td
   <li><a href="#quintessence/Hexagon/Marker.q.yml">quintessence/Hexagon/Marker.q.yml</a></li>
   <li><a href="#quintessence/Hexagon/MarkerNavigator.q.yml">quintessence/Hexagon/MarkerNavigator.q.yml</a></li>
   <li><a href="#quintessence/Hexagon/MissingFile/Stage.q.yml">quintessence/Hexagon/MissingFile/Stage.q.yml</a></li>
+  <li><a href="#quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml">quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml</a></li>
   <li><a href="#quintessence/Hexagon/MultiplexMenu/MenuItem.q.yml">quintessence/Hexagon/MultiplexMenu/MenuItem.q.yml</a></li>
   <li><a href="#quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml">quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml</a></li>
   <li><a href="#quintessence/Hexagon/MultiplexMenu/MultiplexMenuPage.q.yml">quintessence/Hexagon/MultiplexMenu/MultiplexMenuPage.q.yml</a></li>
@@ -6505,6 +6506,37 @@ table td
 </ul>
 <ul>
   <div class="component">
+    <h3 id="quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml">quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml</h3>
+     <table>
+<tr>
+  <td class="property">stage_to_send_messages_to</td>
+  <td class="property">StageInterface*</td>
+</tr>
+<tr>
+  <td class="property">multiplex_menu</td>
+  <td class="property">Hexagon::MultiplexMenu::MultiplexMenu*</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="private_method">send_message_to_stage(1)</td>
+</tr>
+<tr>
+  <td class="method">execute()</td>
+</tr>
+    </table>
+     <table>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;StageInterface*&quot;, &quot;headers&quot;=&gt;[&quot;Hexagon/StageInterface.hpp&quot;]}</td>
+</tr>
+<tr>
+  <td class="dependency">{&quot;symbol&quot;=&gt;&quot;Hexagon::MultiplexMenu::MultiplexMenu*&quot;, &quot;headers&quot;=&gt;[&quot;Hexagon/MultiplexMenu/MultiplexMenu.hpp&quot;]}</td>
+</tr>
+    </table>
+  </div>
+</ul>
+<ul>
+  <div class="component">
     <h3 id="quintessence/Hexagon/MultiplexMenu/MenuItem.q.yml">quintessence/Hexagon/MultiplexMenu/MenuItem.q.yml</h3>
      <table>
 <tr>
@@ -6540,6 +6572,10 @@ table td
 <tr>
   <td class="property">page_history</td>
   <td class="property">std::vector&lt;Hexagon::MultiplexMenu::MultiplexMenuPage*&gt;</td>
+</tr>
+<tr>
+  <td class="property">final_command_to_execute</td>
+  <td class="property">std::string</td>
 </tr>
     </table>
      <table>
@@ -11412,6 +11448,7 @@ table td
     "Hexagon/FullScreenOverlay/Stage",
     "Hexagon/GitCommitMessageInputBox/Stage",
     "Hexagon/MissingFile/Stage",
+    "Hexagon/MultiplexMenu/CommandExecutor",
     "Hexagon/MultiplexMenu/Stage",
     "Hexagon/MultiplexMenu/Stage",
     "Hexagon/NewComponentMaker/Stage",
@@ -12229,6 +12266,13 @@ table td
   "Hexagon/Elements/TexturedRectangle": [
     "Hexagon/MissingFile/Stage"
   ],
+  "Hexagon/MultiplexMenu/MultiplexMenu": [
+    "Hexagon/MultiplexMenu/CommandExecutor",
+    "Hexagon/MultiplexMenu/Renderer",
+    "Hexagon/MultiplexMenu/Stage",
+    "Hexagon/MultiplexMenu/Stage",
+    "Hexagon/StageFactory"
+  ],
   "Hexagon/KeyboardCommandKey": [
     "Hexagon/MultiplexMenu/MenuItem",
     "Hexagon/MultiplexMenu/MultiplexMenuPage",
@@ -12265,12 +12309,6 @@ table td
   "AllegroFlare/color": [
     "Hexagon/MultiplexMenu/PageRenderer",
     "Hexagon/MultiplexMenu/Renderer"
-  ],
-  "Hexagon/MultiplexMenu/MultiplexMenu": [
-    "Hexagon/MultiplexMenu/Renderer",
-    "Hexagon/MultiplexMenu/Stage",
-    "Hexagon/MultiplexMenu/Stage",
-    "Hexagon/StageFactory"
   ],
   "Hexagon/MultiplexMenu/PageRenderer": [
     "Hexagon/MultiplexMenu/Renderer"

--- a/documentation/index.htm
+++ b/documentation/index.htm
@@ -6574,8 +6574,8 @@ table td
   <td class="property">std::vector&lt;Hexagon::MultiplexMenu::MultiplexMenuPage*&gt;</td>
 </tr>
 <tr>
-  <td class="property">final_command_to_execute</td>
-  <td class="property">std::string</td>
+  <td class="property">final_command_set_to_execute</td>
+  <td class="property">std::vector&lt;std::string&gt;</td>
 </tr>
     </table>
      <table>

--- a/include/Hexagon/MultiplexMenu/CommandExecutor.hpp
+++ b/include/Hexagon/MultiplexMenu/CommandExecutor.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+
+#include <Hexagon/MultiplexMenu/MultiplexMenu.hpp>
+#include <Hexagon/StageInterface.hpp>
+#include <string>
+
+
+namespace Hexagon
+{
+   namespace MultiplexMenu
+   {
+      class CommandExecutor
+      {
+      private:
+         StageInterface* stage_to_send_messages_to;
+         Hexagon::MultiplexMenu::MultiplexMenu* multiplex_menu;
+
+      public:
+         CommandExecutor(StageInterface* stage_to_send_messages_to=nullptr, Hexagon::MultiplexMenu::MultiplexMenu* multiplex_menu=nullptr);
+         ~CommandExecutor();
+
+         void send_message_to_stage(std::string message="[message-identifier-set]");
+         void execute();
+      };
+   }
+}
+
+
+

--- a/include/Hexagon/MultiplexMenu/CommandExecutor.hpp
+++ b/include/Hexagon/MultiplexMenu/CommandExecutor.hpp
@@ -21,7 +21,7 @@ namespace Hexagon
          ~CommandExecutor();
 
          void send_message_to_stage(std::string message="[message-identifier-set]");
-         void execute();
+         bool execute();
       };
    }
 }

--- a/include/Hexagon/MultiplexMenu/MultiplexMenu.hpp
+++ b/include/Hexagon/MultiplexMenu/MultiplexMenu.hpp
@@ -16,13 +16,16 @@ namespace Hexagon
       private:
          std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary;
          std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> page_history;
+         std::string final_command_to_execute;
 
       public:
          MultiplexMenu(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary={});
          ~MultiplexMenu();
 
+         void set_final_command_to_execute(std::string final_command_to_execute);
          std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> get_page_dictionary();
          std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> get_page_history();
+         std::string get_final_command_to_execute();
          void set_page_dictionary(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary={});
          int get_num_pages();
          void clear_history();

--- a/include/Hexagon/MultiplexMenu/MultiplexMenu.hpp
+++ b/include/Hexagon/MultiplexMenu/MultiplexMenu.hpp
@@ -16,16 +16,16 @@ namespace Hexagon
       private:
          std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary;
          std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> page_history;
-         std::string final_command_to_execute;
+         std::vector<std::string> final_command_set_to_execute;
 
       public:
          MultiplexMenu(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary={});
          ~MultiplexMenu();
 
-         void set_final_command_to_execute(std::string final_command_to_execute);
+         void set_final_command_set_to_execute(std::vector<std::string> final_command_set_to_execute);
          std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> get_page_dictionary();
          std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> get_page_history();
-         std::string get_final_command_to_execute();
+         std::vector<std::string> get_final_command_set_to_execute();
          void set_page_dictionary(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary={});
          int get_num_pages();
          void clear_history();

--- a/include/Hexagon/System/System.hpp
+++ b/include/Hexagon/System/System.hpp
@@ -113,6 +113,7 @@ public:
 
    // actions
    bool mark_as_files_changed();
+   bool send_commands_from_multiplex_menu_to_editor();
    bool set_frontmost_git_commit_message_input_box_to_submitted_and_pending_destruction();
    bool set_current_project_directory_from_project_navigator_selection();
    bool mark_as_files_committed();
@@ -211,6 +212,7 @@ class System
 {
 public:
    // events
+   static const std::string SEND_COMMANDS_FROM_MULTIPLEX_MENU_TO_EDITOR;
    static const std::string SET_FRONTMOST_GIT_COMMIT_MESSAGE_INPUT_BOX_TO_SUBMITTED_AND_PENDING_DESTRUCTION;
    static const std::string OPEN_HEXAGON_CONFIG_FILE;
    static const std::string WRITE_FOCUSED_COMPONENT_NAME_TO_FILE;

--- a/quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml
@@ -1,0 +1,44 @@
+properties:
+
+
+  - name: stage_to_send_messages_to
+    type: StageInterface*
+    init_with: nullptr
+    constructor_arg: true
+
+  - name: multiplex_menu
+    type: Hexagon::MultiplexMenu::MultiplexMenu*
+    init_with: nullptr
+    constructor_arg: true
+
+
+functions:
+
+
+  - name: send_message_to_stage
+    private: true
+    parameters:
+      - name: message
+        type: std::string
+        default_argument: '"[message-identifier-set]"'
+    guards: [ stage_to_send_messages_to ]
+    body: |
+      stage_to_send_messages_to->process_local_event(message);
+      return;
+
+
+  - name: execute
+    guards: [ stage_to_send_messages_to, multiplex_menu ]
+    body: |
+      send_message_to_stage(multiplex_menu->get_final_command_to_execute());
+
+
+dependencies:
+
+
+  - symbol: StageInterface*
+    headers: [ Hexagon/StageInterface.hpp ]
+  - symbol: Hexagon::MultiplexMenu::MultiplexMenu*
+    headers: [ Hexagon/MultiplexMenu/MultiplexMenu.hpp ]
+
+

--- a/quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/CommandExecutor.q.yml
@@ -29,8 +29,13 @@ functions:
 
   - name: execute
     guards: [ stage_to_send_messages_to, multiplex_menu ]
+    type: bool
     body: |
-      send_message_to_stage(multiplex_menu->get_final_command_to_execute());
+      for (auto &command : multiplex_menu->get_final_command_set_to_execute())
+      {
+         send_message_to_stage(command);
+      }
+      return true;
 
 
 dependencies:

--- a/quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml
@@ -13,9 +13,9 @@ properties:
     init_with: '{}'
     getter: true
 
-  - name: final_command_to_execute
-    type: std::string
-    init_with: '"[command_to_execute-not-set]"'
+  - name: final_command_set_to_execute
+    type: std::vector<std::string>
+    init_with: '{"[command_to_execute-not-set]"}'
     getter: true
     setter: true
 

--- a/quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/MultiplexMenu.q.yml
@@ -13,6 +13,12 @@ properties:
     init_with: '{}'
     getter: true
 
+  - name: final_command_to_execute
+    type: std::string
+    init_with: '"[command_to_execute-not-set]"'
+    getter: true
+    setter: true
+
 
 functions:
 

--- a/quintessence/Hexagon/MultiplexMenu/Stage.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/Stage.q.yml
@@ -135,7 +135,8 @@ functions:
                }
                else
                {
-                  send_message_to_stage(command);
+                  multiplex_menu.set_final_command_to_execute(command);
+                  //send_message_to_stage(command);
                   commands_executed_and_assuming_close_menu = true;
                }
             }
@@ -159,7 +160,8 @@ functions:
     private: true
     body: |
       if (system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design)
-         system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->close_topmost_multiplex_menu();
+         system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->submit_current_modal();
+         //system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->close_topmost_multiplex_menu();
       return;
 
 

--- a/quintessence/Hexagon/MultiplexMenu/Stage.q.yml
+++ b/quintessence/Hexagon/MultiplexMenu/Stage.q.yml
@@ -117,6 +117,8 @@ functions:
          
          Hexagon::MultiplexMenu::MenuItem* menu_item_matching_key =
             find_menu_item_by_keyboard_command_key_on_current_page(this_keyboard_command);
+
+         std::vector<std::string> final_command_set_to_execute;
          
          if (menu_item_matching_key)
          {
@@ -132,10 +134,12 @@ functions:
                {
                   std::string page_name_to_open = extract_menu_item_value_page_name_to_open(command);
                   multiplex_menu.open_page(page_name_to_open);
+                  final_command_set_to_execute.clear();
                }
                else
                {
-                  multiplex_menu.set_final_command_to_execute(command);
+                  final_command_set_to_execute.push_back(command);
+                  //multiplex_menu.set_final_command_to_execute(command);
                   //send_message_to_stage(command);
                   commands_executed_and_assuming_close_menu = true;
                }
@@ -146,6 +150,8 @@ functions:
                std::cout << "Notice: MultiplexMenu/Stage is about to notify the system that it should close the "
                          << "multiplex menu.  The way this is designed, I'm surprised it won't crash.  Keep an "
                          << "eye on it." << std::endl;
+
+               multiplex_menu.set_final_command_set_to_execute(final_command_set_to_execute);
                notify_system_that_its_time_to_close_this_multiplex_menu();
             }
          }

--- a/quintessence/Hexagon/System/EventController.q.yml
+++ b/quintessence/Hexagon/System/EventController.q.yml
@@ -61,6 +61,10 @@ functions:
             &::Hexagon::System::System::send_message_to_daemus_to_build,
          },
          {
+            ::System::SEND_COMMANDS_FROM_MULTIPLEX_MENU_TO_EDITOR,
+            &::Hexagon::System::System::send_commands_from_multiplex_menu_to_editor,
+         },
+         {
             ::System::SET_FRONTMOST_GIT_COMMIT_MESSAGE_INPUT_BOX_TO_SUBMITTED_AND_PENDING_DESTRUCTION,
             &::Hexagon::System::System::set_frontmost_git_commit_message_input_box_to_submitted_and_pending_destruction,
          },

--- a/src/Hexagon/MultiplexMenu/CommandExecutor.cpp
+++ b/src/Hexagon/MultiplexMenu/CommandExecutor.cpp
@@ -1,0 +1,59 @@
+
+
+#include <Hexagon/MultiplexMenu/CommandExecutor.hpp>
+#include <stdexcept>
+#include <sstream>
+#include <stdexcept>
+#include <sstream>
+
+
+namespace Hexagon
+{
+namespace MultiplexMenu
+{
+
+
+CommandExecutor::CommandExecutor(StageInterface* stage_to_send_messages_to, Hexagon::MultiplexMenu::MultiplexMenu* multiplex_menu)
+   : stage_to_send_messages_to(stage_to_send_messages_to)
+   , multiplex_menu(multiplex_menu)
+{
+}
+
+
+CommandExecutor::~CommandExecutor()
+{
+}
+
+
+void CommandExecutor::send_message_to_stage(std::string message)
+{
+   if (!(stage_to_send_messages_to))
+      {
+         std::stringstream error_message;
+         error_message << "CommandExecutor" << "::" << "send_message_to_stage" << ": error: " << "guard \"stage_to_send_messages_to\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   stage_to_send_messages_to->process_local_event(message);
+   return;
+}
+
+void CommandExecutor::execute()
+{
+   if (!(stage_to_send_messages_to))
+      {
+         std::stringstream error_message;
+         error_message << "CommandExecutor" << "::" << "execute" << ": error: " << "guard \"stage_to_send_messages_to\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   if (!(multiplex_menu))
+      {
+         std::stringstream error_message;
+         error_message << "CommandExecutor" << "::" << "execute" << ": error: " << "guard \"multiplex_menu\" not met";
+         throw std::runtime_error(error_message.str());
+      }
+   send_message_to_stage(multiplex_menu->get_final_command_to_execute());
+}
+} // namespace MultiplexMenu
+} // namespace Hexagon
+
+

--- a/src/Hexagon/MultiplexMenu/CommandExecutor.cpp
+++ b/src/Hexagon/MultiplexMenu/CommandExecutor.cpp
@@ -37,7 +37,7 @@ void CommandExecutor::send_message_to_stage(std::string message)
    return;
 }
 
-void CommandExecutor::execute()
+bool CommandExecutor::execute()
 {
    if (!(stage_to_send_messages_to))
       {
@@ -51,7 +51,11 @@ void CommandExecutor::execute()
          error_message << "CommandExecutor" << "::" << "execute" << ": error: " << "guard \"multiplex_menu\" not met";
          throw std::runtime_error(error_message.str());
       }
-   send_message_to_stage(multiplex_menu->get_final_command_to_execute());
+   for (auto &command : multiplex_menu->get_final_command_set_to_execute())
+   {
+      send_message_to_stage(command);
+   }
+   return true;
 }
 } // namespace MultiplexMenu
 } // namespace Hexagon

--- a/src/Hexagon/MultiplexMenu/MultiplexMenu.cpp
+++ b/src/Hexagon/MultiplexMenu/MultiplexMenu.cpp
@@ -13,7 +13,7 @@ namespace MultiplexMenu
 MultiplexMenu::MultiplexMenu(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary)
    : page_dictionary(page_dictionary)
    , page_history({})
-   , final_command_to_execute("[command_to_execute-not-set]")
+   , final_command_set_to_execute({"[command_to_execute-not-set]"})
 {
 }
 
@@ -23,9 +23,9 @@ MultiplexMenu::~MultiplexMenu()
 }
 
 
-void MultiplexMenu::set_final_command_to_execute(std::string final_command_to_execute)
+void MultiplexMenu::set_final_command_set_to_execute(std::vector<std::string> final_command_set_to_execute)
 {
-   this->final_command_to_execute = final_command_to_execute;
+   this->final_command_set_to_execute = final_command_set_to_execute;
 }
 
 
@@ -41,9 +41,9 @@ std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> MultiplexMenu::get_page_
 }
 
 
-std::string MultiplexMenu::get_final_command_to_execute()
+std::vector<std::string> MultiplexMenu::get_final_command_set_to_execute()
 {
-   return final_command_to_execute;
+   return final_command_set_to_execute;
 }
 
 

--- a/src/Hexagon/MultiplexMenu/MultiplexMenu.cpp
+++ b/src/Hexagon/MultiplexMenu/MultiplexMenu.cpp
@@ -13,12 +13,19 @@ namespace MultiplexMenu
 MultiplexMenu::MultiplexMenu(std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> page_dictionary)
    : page_dictionary(page_dictionary)
    , page_history({})
+   , final_command_to_execute("[command_to_execute-not-set]")
 {
 }
 
 
 MultiplexMenu::~MultiplexMenu()
 {
+}
+
+
+void MultiplexMenu::set_final_command_to_execute(std::string final_command_to_execute)
+{
+   this->final_command_to_execute = final_command_to_execute;
 }
 
 
@@ -31,6 +38,12 @@ std::map<std::string, Hexagon::MultiplexMenu::MultiplexMenuPage> MultiplexMenu::
 std::vector<Hexagon::MultiplexMenu::MultiplexMenuPage*> MultiplexMenu::get_page_history()
 {
    return page_history;
+}
+
+
+std::string MultiplexMenu::get_final_command_to_execute()
+{
+   return final_command_to_execute;
 }
 
 

--- a/src/Hexagon/MultiplexMenu/Stage.cpp
+++ b/src/Hexagon/MultiplexMenu/Stage.cpp
@@ -103,6 +103,8 @@ void Stage::process_event(ALLEGRO_EVENT& event)
       
       Hexagon::MultiplexMenu::MenuItem* menu_item_matching_key =
          find_menu_item_by_keyboard_command_key_on_current_page(this_keyboard_command);
+
+      std::vector<std::string> final_command_set_to_execute;
       
       if (menu_item_matching_key)
       {
@@ -118,10 +120,12 @@ void Stage::process_event(ALLEGRO_EVENT& event)
             {
                std::string page_name_to_open = extract_menu_item_value_page_name_to_open(command);
                multiplex_menu.open_page(page_name_to_open);
+               final_command_set_to_execute.clear();
             }
             else
             {
-               multiplex_menu.set_final_command_to_execute(command);
+               final_command_set_to_execute.push_back(command);
+               //multiplex_menu.set_final_command_to_execute(command);
                //send_message_to_stage(command);
                commands_executed_and_assuming_close_menu = true;
             }
@@ -132,6 +136,8 @@ void Stage::process_event(ALLEGRO_EVENT& event)
             std::cout << "Notice: MultiplexMenu/Stage is about to notify the system that it should close the "
                       << "multiplex menu.  The way this is designed, I'm surprised it won't crash.  Keep an "
                       << "eye on it." << std::endl;
+
+            multiplex_menu.set_final_command_set_to_execute(final_command_set_to_execute);
             notify_system_that_its_time_to_close_this_multiplex_menu();
          }
       }

--- a/src/Hexagon/MultiplexMenu/Stage.cpp
+++ b/src/Hexagon/MultiplexMenu/Stage.cpp
@@ -121,7 +121,8 @@ void Stage::process_event(ALLEGRO_EVENT& event)
             }
             else
             {
-               send_message_to_stage(command);
+               multiplex_menu.set_final_command_to_execute(command);
+               //send_message_to_stage(command);
                commands_executed_and_assuming_close_menu = true;
             }
          }
@@ -143,7 +144,8 @@ void Stage::process_event(ALLEGRO_EVENT& event)
 void Stage::notify_system_that_its_time_to_close_this_multiplex_menu()
 {
    if (system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design)
-      system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->close_topmost_multiplex_menu();
+      system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->submit_current_modal();
+      //system_to_tell_when_its_time_to_close_and_by_the_way_this_is_bad_design->close_topmost_multiplex_menu();
    return;
 }
 

--- a/src/Hexagon/System/EventController.cpp
+++ b/src/Hexagon/System/EventController.cpp
@@ -74,6 +74,10 @@ std::map<std::string, std::function<bool(Hexagon::System::System&)>> EventContro
          &::Hexagon::System::System::send_message_to_daemus_to_build,
       },
       {
+         ::System::SEND_COMMANDS_FROM_MULTIPLEX_MENU_TO_EDITOR,
+         &::Hexagon::System::System::send_commands_from_multiplex_menu_to_editor,
+      },
+      {
          ::System::SET_FRONTMOST_GIT_COMMIT_MESSAGE_INPUT_BOX_TO_SUBMITTED_AND_PENDING_DESTRUCTION,
          &::Hexagon::System::System::set_frontmost_git_commit_message_input_box_to_submitted_and_pending_destruction,
       },

--- a/tests/Hexagon/MultiplexMenu/CommandExecutorTest.cpp
+++ b/tests/Hexagon/MultiplexMenu/CommandExecutorTest.cpp
@@ -1,0 +1,12 @@
+
+#include <gtest/gtest.h>
+
+#include <Hexagon/MultiplexMenu/CommandExecutor.hpp>
+
+
+TEST(Hexagon_MultiplexMenu_CommandExecutorTest, can_be_created_without_blowing_up)
+{
+   Hexagon::MultiplexMenu::CommandExecutor command_executor;
+}
+
+


### PR DESCRIPTION
## Problem

There's a bit of a design flaw with `MultiplexMenu` which sends messages to both the parent and to the editor by having those objects injected into the menu, and the menu executes the commands.  This is a bit odd because a _menu_ should not be managing the execution of any commands at the system or at the editor level.  In general, a menu should be an inactive list that only concerns itself with the curation and selection of items in its list - not a full fledged execution manager.

## Solution

This PR will modify the `MultiplexMenu` slightly so that it will act more as a proper modal stage (the general design of the modal-typeness does require a bit of refactoring, not for discussion here - it's kinda managed in the base `StageInterface` class which is not great).

As an improvement, the MultiplexMenu will now notify `System` that it, as a modal, has "submit"ted.  The actions that happen as a result of the submission of the modal will be handled by `Hexagon/System` via `send_commands_from_multiplex_menu_to_editor()` which will delegate to `MultiplexMenu/CommandExecutor`.

One thing that is different in this regard is the modal is executing the submission itself (which could possibly be a new type of design to be used).  Currently, all modals are submitted by hitting the `ENTER` key and the `ENTER` keypress signals to `System` to submit whatever modal is on top.  But in this case, the multiplex menu is a bit different in that it will only be submitted by a keypress (and what keypress that is can vary depending on what menu page is currently open.), and _not_ purely with the `ENTER` key, which would be too slow and clunky of an interface to use.